### PR TITLE
Bug: wrong area used in Sections with non-uniform diameter

### DIFF
--- a/extracellular_electrode.hoc
+++ b/extracellular_electrode.hoc
@@ -114,7 +114,7 @@ proc re_insert_elec(){
 					dis = (diam/2) + 0.1
 
 		}
-		point_part1 = (1 / (4 * 3.141 * dis * sigma)) * area(0.5)
+		point_part1 = (1 / (4 * 3.141 * dis * sigma))
 
 
 		//calculate length of the compartment
@@ -166,7 +166,7 @@ proc re_insert_elec(){
 		}
 
 
-		line_part1 = 1/(4*PI*sum_dist_comp*sigma) * phi * area(0.5)
+		line_part1 = 1/(4*PI*sum_dist_comp*sigma) * phi
 
 
 		// RC algorithm implementation
@@ -174,7 +174,7 @@ proc re_insert_elec(){
 		RC = sigma * capa
 	
 		time_const = dis / 240 // velo um/ms  // Nauhaus et al, 2009 calculated the propagation speed on average, 0.24 ± 0.20 m/s in monkeys and 0.31 ± 0.23 m/s in cats (mean ± s.d.) ie, 240 um/ms
-		rc_part1 =  exp(-1 *(time_const/RC)) * area(0.5)
+		rc_part1 =  exp(-1 *(time_const/RC))
 
 		for (x, 0) {
 
@@ -182,11 +182,11 @@ proc re_insert_elec(){
 		
 			setpointer transmembrane_current_lfp(x), i_membrane(x)
 			
-			initial_part_point_lfp(x) = point_part1
+			initial_part_point_lfp(x) = point_part1 * area(x)
 			
-			initial_part_line_lfp(x) = line_part1
+			initial_part_line_lfp(x) = line_part1 * area(x)
 
-			initial_part_rc_lfp(x) = rc_part1
+			initial_part_rc_lfp(x) = rc_part1 * area(x)
 						
 				
 		}
@@ -342,4 +342,3 @@ proc run_multi_button(){
 
 	}
 }
-


### PR DESCRIPTION
There was a bug where for each compartment (segment), area(0.5) (at the center of the Section) was used rather than the compartment's real area. This would yield wrong results in the case of non-uniform diameters.